### PR TITLE
Issue #37: Account for custom modules

### DIFF
--- a/core/modules/admin_bar/admin_bar.info
+++ b/core/modules/admin_bar/admin_bar.info
@@ -1,10 +1,10 @@
+type = module
 name = Administration bar
 description = "Provides a dropdown menu to most administrative tasks and other common destinations."
 package = Administration
-tags[] = Administration
+tags[] = Menus
 tags[] = Site Navigation
-tags[] = Core
-backdrop = 1.x
-configure = admin/config/administration/admin-bar
 version = BACKDROP_VERSION
-type = module
+backdrop = 1.x
+
+configure = admin/config/administration/admin-bar

--- a/core/modules/block/block.info
+++ b/core/modules/block/block.info
@@ -1,11 +1,10 @@
+type = module
 name = Block
 description = Controls the visual building blocks a page is constructed with. Blocks are boxes of content rendered into an area, or region, of a web page.
-package = Layout
-tags[] = Layout
+package = Layouts
 tags[] = Blocks
-tags[] = Content Display
-tags[] = Core
+tags[] = Site Architecture
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
+
 configure = admin/structure/block

--- a/core/modules/book/book.info
+++ b/core/modules/book/book.info
@@ -1,12 +1,12 @@
+type = module
 name = Book
 description = Allows users to create and organize related content in an outline.
 package = System
-tags[] = System
-tags[] = Content Display
+tags[] = Content
 tags[] = Site Navigation
-tags[] = Core
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
+
 dependencies[] = node
+
 configure = admin/content/book/settings

--- a/core/modules/ckeditor/ckeditor.info
+++ b/core/modules/ckeditor/ckeditor.info
@@ -1,10 +1,11 @@
+type = module
 name = CKEditor
 description = WYSIWYG editing for rich text fields using CKEditor.
-package = User interface
-tags[] = User interface
-tags[] = Filters and Editors
-tags[] = Core
+package = User Interface
+tags[] = Filters
+tags[] = Formats
+tags[] = Text Editors
 version = BACKDROP_VERSION
 backdrop = 1.x
-type = module
+
 configure = admin/config/content/formats

--- a/core/modules/color/color.info
+++ b/core/modules/color/color.info
@@ -1,9 +1,7 @@
+type = module
 name = Color
 description = Allows administrators to change the color scheme of compatible themes.
 package = Appearance
-tags[] = Appearance
 tags[] = Theme Enhancements
-tags[] = Core
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x

--- a/core/modules/comment/comment.info
+++ b/core/modules/comment/comment.info
@@ -1,13 +1,13 @@
+type = module
 name = Comment
 description = Allows users to comment on and discuss published content.
 package = Comments
-tags[] = Comments
-tags[] = Core
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = node
 dependencies[] = text
 dependencies[] = entity
+
 configure = admin/content/comment
+
 stylesheets[all][] = css/comment.css

--- a/core/modules/comment/tests/comment.test
+++ b/core/modules/comment/tests/comment.test
@@ -2034,20 +2034,20 @@ class CommentFieldsTest extends CommentHelperCase {
 
     // Disable the comment module.
     $edit = array();
-    $edit['modules[comment][enable]'] = FALSE;
+    $edit['modules[Comments][comment][enable]'] = FALSE;
     $this->backdropPost('admin/modules', $edit, t('Save configuration'));
     $this->resetAll();
     $this->assertFalse(module_exists('comment'), 'Comment module disabled.');
 
     // Enable core content type module: book.
     $edit = array();
-    $edit['modules[book][enable]'] = 'book';
+    $edit['modules[System][book][enable]'] = 'book';
     $this->backdropPost('admin/modules', $edit, t('Save configuration'));
     $this->resetAll();
 
     // Now enable the comment module.
     $edit = array();
-    $edit['modules[comment][enable]'] = 'comment';
+    $edit['modules[Comments][comment][enable]'] = 'comment';
     $this->backdropPost('admin/modules', $edit, t('Save configuration'));
     $this->resetAll();
     $this->assertTrue(module_exists('comment'), 'Comment module enabled.');

--- a/core/modules/config/config.info
+++ b/core/modules/config/config.info
@@ -1,9 +1,11 @@
+type = module
 name = Configuration manager
 description = Import, export, and synchronize your configuration changes between different installations of your site, such as in development, staging, and production environments.
-version = BACKDROP_VERSION
-type = module
-backdrop = 1.x
-configure = admin/config/development/configuration
 package = Development
-tags[] = Development
-tags[] = Core
+tags[] = Site Architecture
+tags[] = System
+version = BACKDROP_VERSION
+backdrop = 1.x
+
+configure = admin/config/development/configuration
+

--- a/core/modules/contact/contact.info
+++ b/core/modules/contact/contact.info
@@ -1,10 +1,10 @@
+type = module
 name = Contact
 description = Enables the use of both personal and site-wide contact forms.
 package = System
-tags[] = System
 tags[] = Mail
-tags[] = Core
+tags[] = Utility
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
+
 configure = admin/structure/contact

--- a/core/modules/contextual/contextual.info
+++ b/core/modules/contextual/contextual.info
@@ -1,8 +1,8 @@
+type = module
 name = Contextual Links
 description = Provides contextual links to perform actions related to elements on a page.
-package = Administration
+package = User Interface
 tags[] = Administration
-tags[] = Core
+tags[] = Site Navigation
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x

--- a/core/modules/date/date.info
+++ b/core/modules/date/date.info
@@ -1,11 +1,10 @@
+type = module
 name = Date
 description = Makes date/time fields available.
 package = Fields
-tags[] = Fields
-tags[] = Date
-tags[] = Core
+tags[] = Dates
+tags[] = Content
 version = BACKDROP_VERSION
 backdrop = 1.x
-type = module
 
 stylesheets[all][] = css/date.css

--- a/core/modules/dblog/dblog.info
+++ b/core/modules/dblog/dblog.info
@@ -1,8 +1,7 @@
+type = module
 name = Database Logging
 description = Logs and records system events to the database.
 package = Development
-tags[] = Development
-tags[] = Core
+tags[] = Logging
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x

--- a/core/modules/email/email.info
+++ b/core/modules/email/email.info
@@ -1,9 +1,9 @@
+type = module
 name = Email
 description = Defines an email field type.
 package = Fields
-tags[] = Fields
-tags[] = Email
-tags[] = Core
+tags[] = Mail
+tags[] = Content
 version = BACKDROP_VERSION
 backdrop = 1.x
-type = module
+

--- a/core/modules/entity/entity.info
+++ b/core/modules/entity/entity.info
@@ -1,9 +1,8 @@
+type = module
 name = Entity
 description = API for managing entities like nodes and users.
 package = System
-tags[] = System
-tags[] = Core
+tags[] = Content
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE

--- a/core/modules/field/field.info
+++ b/core/modules/field/field.info
@@ -1,13 +1,12 @@
+type = module
 name = Field
 description = Field API to add fields to entities like nodes and users.
 package = System
-tags[] = System
 tags[] = Fields
-tags[] = Core
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = field_sql_storage
 dependencies[] = entity
 required = TRUE
+
 stylesheets[all][] = css/field.css

--- a/core/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/core/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -1,10 +1,9 @@
+type = module
 name = Field SQL Storage
 description = Stores field data in an SQL database.
 package = Fields
-tags[] = Fields
-tags[] = Core
+tags[] = System
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = field
 required = TRUE

--- a/core/modules/field/modules/list/list.info
+++ b/core/modules/field/modules/list/list.info
@@ -1,10 +1,9 @@
+type = module
 name = List
 description = Defines list field types. Use with Options to create selection lists.
 package = Fields
-tags[] = Fields
-tags[] = Core
+tags[] = Content
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = field
 dependencies[] = options

--- a/core/modules/field/modules/number/number.info
+++ b/core/modules/field/modules/number/number.info
@@ -1,9 +1,8 @@
+type = module
 name = Number
 description = Defines numeric field types.
 package = Fields
-tags[] = Fields
-tags[] = Core
+tags[] = Content
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = field

--- a/core/modules/field/modules/options/options.info
+++ b/core/modules/field/modules/options/options.info
@@ -1,9 +1,8 @@
+type = module
 name = Options
 description = Defines selection, check box and radio button widgets for text and numeric fields.
 package = Fields
-tags[] = Fields
-tags[] = Core
+tags[] = Content
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = field

--- a/core/modules/field_ui/field_ui.info
+++ b/core/modules/field_ui/field_ui.info
@@ -1,9 +1,8 @@
+type = module
 name = Field UI
 description = User interface for the Field API.
 package = Fields
-tags[] = Fields
-tags[] = Core
+tags[] = User Interface
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = field

--- a/core/modules/file/file.info
+++ b/core/modules/file/file.info
@@ -1,11 +1,10 @@
+type = module
 name = File
 description = Defines a file field type.
 package = Fields
-tags[] = Fields
 tags[] = File Management
-tags[] = Core
+tags[] = Media
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE
 dependencies[] = field

--- a/core/modules/filter/filter.info
+++ b/core/modules/filter/filter.info
@@ -1,11 +1,12 @@
+type = module
 name = Filter
 description = Filters content in preparation for display.
 package = System
-tags[] = System
-tags[] = Filters and Editors
-tags[] = Core
+tags[] = Filters
+tags[] = Formats
+tags[] = Text Editors
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE
+
 configure = admin/config/content/formats

--- a/core/modules/image/image.info
+++ b/core/modules/image/image.info
@@ -1,12 +1,11 @@
+type = module
 name = Image
 description = Provides image manipulation tools and image field type.
 package = Fields
-tags[] = Fields
-tags[] = Image
+tags[] = Images
 tags[] = Media
-tags[] = Core
+tags[] = Content
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 dependencies[] = file
 configure = admin/config/media/image-styles

--- a/core/modules/installer/installer.info
+++ b/core/modules/installer/installer.info
@@ -1,10 +1,8 @@
+type = module
 name = Project Installer
 description = Provides a user interface for installing and updating modules, themes, and layouts.
 version = BACKDROP_VERSION
-type = module
 package = Development
-tags[] = Development
 tags[] = User interface
-tags[] = Core
 backdrop = 1.x
 dependencies[] = update

--- a/core/modules/language/language.info
+++ b/core/modules/language/language.info
@@ -1,8 +1,7 @@
 name = Language
 description = Lets you configure a number of languages to be used on your website.
 package = Translation
-tags[] = Language and Translation
-tags[] = Core
+tags[] = Language
 version = BACKDROP_VERSION
 type = module
 backdrop = 1.x

--- a/core/modules/layout/layout.info
+++ b/core/modules/layout/layout.info
@@ -1,9 +1,9 @@
+type = module
 name = Layout
 description = Provides a drag and drop page building tool.
-package = Layout
-tags[] = Layout
-tags[] = Core
+package = Layouts
+tags[] = Blocks
+tags[] = Site Architecture
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE

--- a/core/modules/link/link.info
+++ b/core/modules/link/link.info
@@ -1,8 +1,8 @@
+type = module
 name = Link
 description = Defines simple link field types.
 package = Fields
-tags[] = Fields
-tags[] = Core
+tags[] = Content
 version = BACKDROP_VERSION
 backdrop = 1.x
-type = module
+

--- a/core/modules/locale/locale.info
+++ b/core/modules/locale/locale.info
@@ -1,8 +1,7 @@
 name = Locale
 description = Provides language negotiation functionality and user interface translation to languages other than English.
 package = Translation
-tags[] = Language and Translation
-tags[] = Core
+tags[] = Language
 version = BACKDROP_VERSION
 type = module
 backdrop = 1.x

--- a/core/modules/menu/menu.info
+++ b/core/modules/menu/menu.info
@@ -1,9 +1,10 @@
 name = Menu
 description = Allows administrators to customize the site navigation menu.
 package = System
-tags[] = System
-tags[] = Core
+tags[] = Menus
+tags[] = Site Navigation
 version = BACKDROP_VERSION
 type = module
 backdrop = 1.x
+
 configure = admin/structure/menu

--- a/core/modules/node/node.info
+++ b/core/modules/node/node.info
@@ -1,11 +1,9 @@
+type = module
 name = Node
 description = Allows content to be submitted to the site and displayed on pages.
 package = System
 tags[] = Content
-tags[] = System
-tags[] = Core
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE
 dependencies[] = entity

--- a/core/modules/path/path.info
+++ b/core/modules/path/path.info
@@ -1,10 +1,9 @@
 name = Path
 description = Allows users to rename URLs.
 package = System
-tags[] = System
-tags[] = Path Management
-tags[] = Core
+tags[] = URL Handling
 version = BACKDROP_VERSION
 type = module
 backdrop = 1.x
+
 configure = admin/config/urls/path

--- a/core/modules/redirect/redirect.info
+++ b/core/modules/redirect/redirect.info
@@ -1,10 +1,9 @@
+type = module
 name = Redirect
 description = Allows users to redirect from old URLs to new URLs.
 package = System
-tags[] = Path Management
-tags[] = System
-tags[] = Core
+tags[] = URL handling
 backdrop = 1.x
 version = BACKDROP_VERSION
-type = module
+
 configure = admin/config/urls/redirect/settings

--- a/core/modules/search/search.info
+++ b/core/modules/search/search.info
@@ -1,10 +1,11 @@
+type = module
 name = Search
 description = Enables site-wide keyword searching.
 package = Search
-tags[] = Search
-tags[] = Core
+tags[] = Utility
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
+
 configure = admin/config/search/settings
+
 stylesheets[all][] = search.theme.css

--- a/core/modules/simpletest/simpletest.info
+++ b/core/modules/simpletest/simpletest.info
@@ -1,9 +1,9 @@
+type = module
 name = Testing
 description = Provides a framework for unit and functional testing.
 package = Development
-tags[] = Development
-tags[] = Core
+tags[] = Testing
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
+
 configure = admin/config/development/testing/settings

--- a/core/modules/syslog/syslog.info
+++ b/core/modules/syslog/syslog.info
@@ -1,9 +1,9 @@
-name = Syslog
+type = module
+name = System Logging
 description = Logs and records system events to syslog.
 package = Development
-tags[] = Development
-tags[] = Core
+tags[] = Logging
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
+
 configure = admin/config/development/logging

--- a/core/modules/system/css/system.admin.css
+++ b/core/modules/system/css/system.admin.css
@@ -70,6 +70,33 @@ small .admin-link:after {
 /**
  * Modules page.
  */
+#system-modules .table-filter {
+  margin: 1em 0;
+  padding: 7px 13px;
+  border-radius: 4px;
+  background-color: #fff;
+  border: 2px solid #EAEAEA;
+}
+#system-modules .form-item-search,
+#system-modules .form-item-tags,
+#system-modules .form-item-source {
+  display: inline-block;
+  padding-right: 1em; /* LTR */
+}
+[dir="rtl"] #system-modules .form-item-search,
+[dir="rtl"] #system-modules .form-item-tags,
+[dir="rtl"] #system-modules .form-item-source  {
+  padding-right: 0;
+  padding-left: 1em;
+}
+#system-modules .form-type-checkbox {
+  display: inline-block;
+  padding-right: .75em; /* LTR */
+}
+[dir="rtl"] #system-modules .form-type-checkbox {
+  padding-right: 0;
+  padding-left: .75em;
+}
 #system-modules div.incompatible {
   font-weight: bold;
 }

--- a/core/modules/system/js/modules.js
+++ b/core/modules/system/js/modules.js
@@ -6,13 +6,12 @@
  * Additionally accounts for multiple tables being wrapped in "package" fieldset
  * elements.
  */
-Backdrop.behaviors.moduleFilterByText = {
+Backdrop.behaviors.moduleFilter = {
   attach: function(context, settings) {
     var $input = $('input.table-filter-text').once('table-filter-text');
     var $form = $('#system-modules');
     var $rowsAndFieldsets, $rows, $fieldsets;
 
-    var tagRows = [];
     // Hide the module requirements.
     $form.find('.requirements').hide();
 
@@ -29,26 +28,26 @@ Backdrop.behaviors.moduleFilterByText = {
       e.stopPropagation();
     });
 
-    // Filter the list of modules by provided search string.
-    function filterModuleListBySearch() {
-      var query = $input.val().toLowerCase();
+    // Hide the package <fieldset> if it doesn't have any visible rows within.
+    function hidePackageFieldset(index, element) {
+      var $fieldset = $(element);
+      var $visibleRows = $fieldset.find('table:not(.sticky-header)').find('tbody tr:visible');
+      $fieldset.toggle($visibleRows.length > 0);
+    }
 
-      // Todo add magic search:
-        // 'ddd' for disabled and 'eee' for enabled
-        // '-' + '<search-term>' to negate search
+    // Fliter the list of modules by provided search string.
+    function filterModuleList() {
+      var query = $input.val().toLowerCase();
+      var tag = $('select[data-filter-tags]').val();
+      var core = $('input[data-filter-source="core"]').is(":checked");
+      var contrib = $('input[data-filter-source="contrib"]').is(":checked");
 
       function showModuleRow(index, row) {
-        if ($('#edit-target').is(':checked')) {
-          var searchTarget = '.module-tags';
-        }
-        else {
-          var searchTarget = '.table-filter-text-source';
-        }
-
         var $row = $(row);
         var $sources = $row.find('.table-filter-text-source');
         var rowMatch = $sources.text().toLowerCase().indexOf(query) !== -1;
         var $fieldsetTitle = $row.closest('fieldset').find('legend:first');
+        var tagSource = $row.find('.module-tags').text().toLowerCase();
 
         // Finding the fieldset title and filtering it can be expensive and
         // repetitive to do for every row, so save the filtered title as data on
@@ -62,21 +61,31 @@ Backdrop.behaviors.moduleFilterByText = {
         else {
           filterTitle = $fieldsetTitle.data('filterTitle');
         }
+        // Compare the search query to the fieldset title.
         var fieldsetTitleMatch = filterTitle.indexOf(query) !== -1;
+        // Compare the requested tag to each row's tags.
+        var tagMatch = tagSource.indexOf(tag) !== -1;
+
+        // Check the module souce and show only if matched.
+        var sourceMatch = false;
+        if ($row.hasClass('core') && core ) {
+          sourceMatch = true;
+        }
+        if ($row.hasClass('contrib') && contrib) {
+          sourceMatch = true;
+        }
 
         // If the row contains the string or the fieldset does, show the row.
-        $row.closest('tr').toggle(rowMatch || fieldsetTitleMatch);
+        $row.closest('tr').toggle((rowMatch || fieldsetTitleMatch) && tagMatch && sourceMatch);
       }
 
-      // Filter only if the length of the query is at least 2 characters.
-      if (query.length >= 2) {
-        $(tagRows).each(function( index ) {
-          showModuleRow(query, this, '.table-filter-text-source');
-        });
-
+      // Filter only if the length of the search query is at least 2 characters.
+      if (query.length >= 2 || tag || !core || !contrib) {
         $('#edit-target').on('change', function() {
           $rows.each(showModuleRow);
         });
+
+        $rows.each(showModuleRow);
 
         // We first show() all <fieldset>s to be able to use ':visible'.
         $fieldsets.show().each(hidePackageFieldset);
@@ -91,79 +100,8 @@ Backdrop.behaviors.moduleFilterByText = {
         }
       }
       else {
-        $.each(tagRows, function() {
-          $(this).show();
-        });
-      }
-    }
-
-    // Filter the list of modules by tags.
-    // Creates an array ('tagRows')of modules matching the selected tags, as a
-    // subset of the $rows object, which is used by filterModuleListBySearch()
-    // instead of $rows to do further filtering.
-    function filterModuleListByTag() {
-      var $selecTag = $('#edit-tags').val().toLowerCase();
-      // If 'All tags' selected, show all tags and add all to tagRows.
-      if ($selecTag == 'all') {
-        $rows.each(function( index ) {
-          $(this).closest('tr').show();
-          tagRows.push(this);
-        });
-      }
-      else {
-        tagRows = [];
-        $rows.each(function( index ) {
-          // Filter by tag and add matches to tagRows.
-          row = showModuleRow($selecTag, this, '.module-tags');
-          tagRows.push(row);
-        });
-      }
-
-      // Toggle no results string
-      if ($rows.filter(':visible').length === 0) {
-        if ($('.filter-empty').length === 0) {
-          $('#edit-filter').append('<p class="filter-empty">' + Backdrop.t('There were no results.') + '</p>');
-        }
-      }
-      else {
+        $rowsAndFieldsets.show();
         $('.filter-empty').remove();
-      }
-    }
-
-    // Filters each module row based either on tag or search string and returns
-    // the row if it matches.
-    function showModuleRow(selecTag, row, searchTarget) {
-      var $row = $(row);
-      var $sources = $row.find(searchTarget);
-      var coreHidden = $('#edit-core-switch-core').prop("checked") === false;
-      var contribHidden = $('#edit-core-switch-contrib').prop("checked") === false;
-      console.log($sources);
-      if (selecTag != 'all') {
-        var textMatch = $sources.text().toLowerCase().indexOf(selecTag) !== -1;
-      }
-      else {
-        var textMatch = true;
-      }
-      var coreMatch = $sources.text().toLowerCase().indexOf("core") !== -1;
-      if (coreHidden && coreMatch) {
-        $row.closest('tr').hide();
-      }
-      else if(contribHidden && !coreMatch) {
-        $row.closest('tr').hide();
-      }
-      else {
-        $row.closest('tr').toggle(textMatch);
-      }
-      if(textMatch) {
-        return row;
-      }
-    }
-
-    // Toggles rows when the 'Hide core' checkbox is toggled.
-    function filterCore() {
-      filterModuleListByTag();
-      if ($input.val().toLowerCase().length >= 2) {
-        filterModuleListBySearch();
       }
     }
 
@@ -174,30 +112,10 @@ Backdrop.behaviors.moduleFilterByText = {
 
       // @todo Use autofocus attribute when possible.
       $input.focus().on('keyup', filterModuleList);
+      $('select[data-filter-tags]').change(filterModuleList);
+      $('input[data-filter-source]').change(filterModuleList);
       $input.triggerHandler('keyup');
-      $('#edit-tags').on('change', filterModuleListByTag);
-      $('#edit-core-switch-core').on('change', filterCore);
-      $('#edit-core-switch-contrib').on('change', filterCore);
     }
-
-    corefltr = $form.find('#edit-core-switch-core');
-    contribfltr = $form.find('#edit-core-switch-contrib');
-    corefltr.change(function() {
-      if (corefltr.is(':not(:checked)')) {
-          contribfltr.prop('disabled', true);
-      }
-      else {
-        contribfltr.prop('disabled', false);
-      }
-    });
-    contribfltr.change(function() {
-      if (contribfltr.is(':not(:checked)')) {
-          corefltr.prop('disabled', true);
-      }
-      else {
-        corefltr.prop('disabled', false);
-      }
-    });
   }
 };
 

--- a/core/modules/system/js/modules.js
+++ b/core/modules/system/js/modules.js
@@ -41,6 +41,7 @@ Backdrop.behaviors.moduleFilter = {
       var tag = $('select[data-filter-tags]').val();
       var core = $('input[data-filter-source="core"]').is(":checked");
       var contrib = $('input[data-filter-source="contrib"]').is(":checked");
+      var custom = $('input[data-filter-source="custom"]').is(":checked");
 
       function showModuleRow(index, row) {
         var $row = $(row);
@@ -74,13 +75,16 @@ Backdrop.behaviors.moduleFilter = {
         if ($row.hasClass('contrib') && contrib) {
           sourceMatch = true;
         }
+        if ($row.hasClass('custom') && custom) {
+          sourceMatch = true;
+        }
 
         // If the row contains the string or the fieldset does, show the row.
         $row.closest('tr').toggle((rowMatch || fieldsetTitleMatch) && tagMatch && sourceMatch);
       }
 
       // Filter only if the length of the search query is at least 2 characters.
-      if (query.length >= 2 || tag || !core || !contrib) {
+      if (query.length >= 2 || tag || !core || !contrib || !custom) {
         $('#edit-target').on('change', function() {
           $rows.each(showModuleRow);
         });

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -504,9 +504,9 @@ function system_modules($form, $form_state = array()) {
   );
   $form['filter']['search'] = array(
     '#type' => 'textfield',
-    '#title' => t('Filter'),
+    '#title' => t('Keyword'),
     '#size' => 30,
-    '#placeholder' => t('Enter module name…'),
+    '#placeholder' => t('Search...'),
     '#attributes' => array(
       'class' => array('table-filter-text'),
       'autocomplete' => 'off',
@@ -518,41 +518,62 @@ function system_modules($form, $form_state = array()) {
   // Get current list of modules.
   $files = system_rebuild_module_data();
 
-  // Remove hidden modules from display list.
-  //Build tag list
   $visible_files = $files;
   $all_tags = array();
   foreach ($visible_files as $filename => $file) {
-    if (!empty($file->info['hidden'])) {
+    // Remove hidden and required modules from display list.
+    if (!empty($file->info['hidden'] || !empty($file->info['required']))) {
       unset($visible_files[$filename]);
     }
-    if (isset($file->info['tags'])) {
-      $all_tags = array_merge($all_tags, $file->info['tags']);
+    else {
+      // Build tag list.
+      $module_tags = array();
+      if (isset($file->info['tags'])) {
+        $module_tags = $file->info['tags'];
+      }
+      // Include packages in tag list.
+      if (isset($file->info['package'])) {
+        $module_tags[] = $file->info['package'];
+      }
+
+      if (!empty($module_tags)) {
+        $all_tags = array_merge($all_tags, $module_tags);
+      }
+      else {
+        $all_tags = array_merge($all_tags, array('other' => t('Other')));
+      }
     }
   }
-  
-  // Add list of available tags to js
+
+  // Generate a list of available tags.
   $tags = array();
   foreach ($all_tags as $tag) {
-    $tags[$tag] = $tag;
+    $tagname = strtolower($tag);
+    $tags[$tagname] = $tag;
   }
   asort($tags);
-  $tags = array('All' => 'All tags') + $tags;
+  $tags = array('' => '- Any -') + $tags;
 
+  // Add tags filter.
   $form['filter']['tags'] = array(
     '#type' => 'select',
-    '#title' => t('Search by tags'),
+    '#title' => t('Tag'),
     '#options' => $tags,
+    '#default_value' => array(''),
+    '#attributes' => array('data-filter-tags' => 'tags')
   );
 
-  $form['filter']['core_switch'] = array(
+  // Add core/contrib filter.
+  $form['filter']['source'] = array(
     '#type' => 'checkboxes',
-    '#title' => t('Show the following modules'),
+    '#title' => t('Module source'),
     '#default_value' => array('core', 'contrib'),
     '#options' => array(
-      'core' => 'Core',
-      'contrib' => 'Contrib',
+      'core' => 'Backdrop core',
+      'contrib' => 'Contributed projects',
     ),
+    'core' => array('#attributes' => array('data-filter-source' => 'core')),
+    'contrib' => array('#attributes' => array('data-filter-source' => 'contrib')),
   );
 
   uasort($visible_files, 'system_sort_modules_by_info_name');
@@ -666,16 +687,15 @@ function system_modules($form, $form_state = array()) {
         }
       }
     }
-    $form['modules'][$filename] = _system_modules_build_row($module->info, $extra);
+    $form['modules'][$module->info['package']][$filename] = _system_modules_build_row($module->info, $extra);
   }
-  // Lastly, sort all fieldsets by title.
-  // backdrop_sort($form['modules'], array($filename => SORT_STRING));
-  
+
   // Add basic information to the fieldsets.
-    $form['modules'] += array(
-      '#type' => 'container',
-      // '#title' => t('mods'),
-      // '#collapsible' => TRUE,
+  foreach (element_children($form['modules']) as $package) {
+    $form['modules'][$package] += array(
+      '#type' => 'fieldset',
+      '#title' => t($package),
+      '#collapsible' => TRUE,
       '#theme' => 'system_modules_fieldset',
       '#header' => array(
         array('class' => array('checkbox')),
@@ -685,6 +705,7 @@ function system_modules($form, $form_state = array()) {
         array('data' => t('Operations')),
       ),
     );
+  }
 
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['submit'] = array(
@@ -692,7 +713,7 @@ function system_modules($form, $form_state = array()) {
     '#value' => t('Save configuration'),
   );
   $form['#action'] = url('admin/modules/list/confirm');
-  
+
   return $form;
 }
 
@@ -720,6 +741,20 @@ function system_sort_themes($a, $b) {
  * Build a table row for the system modules page.
  */
 function _system_modules_build_row($info, $extra) {
+  // Prepare tag list by assureing all are lower case.
+  $tags = array();
+  if (isset($info['tags'])) {
+    foreach ($info['tags'] as $tag) {
+      $tags[] = $tag;
+    }
+  }
+  if (isset($info['package'])) {
+    $tags[] = $info['package'];
+  }
+  if (empty($tags)) {
+    $tags[] = 'Other';
+  }
+
   // Add in the defaults.
   $extra += array(
     'requires' => array(),
@@ -742,19 +777,11 @@ function _system_modules_build_row($info, $extra) {
   $form['version'] = array(
     '#markup' => $info['version'],
   );
-  $tags = array();
-  if(isset($info['tags'])) {
-    $tags = $info['tags'];
-  }
-  elseif(isset($info['package'])) {
-    $tags[] = $info['package'];
-  }
-  else {
-    $tags[] = 'Other'; 
-  }
   $form['tags'] = array(
     '#markup' => implode(', ', $tags),
   );
+
+  $form['core'] = $extra['core'];
   $form['#requires'] = $extra['requires'];
   $form['#required_by'] = $extra['required_by'];
   $form['#required_by_distribution'] = $extra['required_by_distribution'];

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -604,7 +604,7 @@ function system_modules($form, $form_state = array()) {
       $extra['required_by'][] = $module->info['explanation'];
     }
 
-    // Check to see if this is a core/contrib/custom.
+    // Check to see if this is a core/contrib/custom module.
     if (strstr($module->uri, 'core/modules')) {
       $extra['core'] = TRUE;
     }

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -563,17 +563,19 @@ function system_modules($form, $form_state = array()) {
     '#attributes' => array('data-filter-tags' => 'tags')
   );
 
-  // Add core/contrib filter.
+  // Add core/contrib/custom filter.
   $form['filter']['source'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Module source'),
-    '#default_value' => array('core', 'contrib'),
+    '#default_value' => array('core', 'contrib', 'custom'),
     '#options' => array(
       'core' => 'Backdrop core',
       'contrib' => 'Contributed projects',
+      'custom' => 'Custom modules',
     ),
     'core' => array('#attributes' => array('data-filter-source' => 'core')),
     'contrib' => array('#attributes' => array('data-filter-source' => 'contrib')),
+    'custom' => array('#attributes' => array('data-filter-source' => 'custom')),
   );
 
   uasort($visible_files, 'system_sort_modules_by_info_name');
@@ -602,9 +604,15 @@ function system_modules($form, $form_state = array()) {
       $extra['required_by'][] = $module->info['explanation'];
     }
 
-    // Check to see if this is a core module.
+    // Check to see if this is a core/contrib/custom.
     if (strstr($module->uri, 'core/modules')) {
       $extra['core'] = TRUE;
+    }
+    elseif (!$module->info['project'] && !$module->info['version'] && !$module->info['timestamp']) {
+      $extra['custom'] = TRUE;
+    }
+    else {
+      $extra['contrib'] = TRUE;
     }
 
     // Some modules are always required by core and cannot be disabled, for
@@ -763,6 +771,8 @@ function _system_modules_build_row($info, $extra) {
     'enabled' => FALSE,
     'links' => array(),
     'core' => FALSE,
+    'contrib' => FALSE,
+    'custom' => FALSE,
   );
   $form = array(
     '#tree' => TRUE,
@@ -782,6 +792,8 @@ function _system_modules_build_row($info, $extra) {
   );
 
   $form['core'] = $extra['core'];
+  $form['contrib'] = $extra['contrib'];
+  $form['custom'] = $extra['custom'];
   $form['#requires'] = $extra['requires'];
   $form['#required_by'] = $extra['required_by'];
   $form['#required_by_distribution'] = $extra['required_by_distribution'];
@@ -815,8 +827,8 @@ function _system_modules_build_row($info, $extra) {
     $status_long .= t('This module requires PHP version @php_required and is incompatible with PHP version !php_version.', array('@php_required' => $php_required, '!php_version' => phpversion())) . ' ';
   }
 
-  // If this module is compatible, present a checkbox indicating this module
-  // may be installed. Otherwise, show a big red X.
+  // If this module is compatible, present a checkbox indicating this module may
+  // be installed. Otherwise, show a big red X.
   if ($compatible) {
     $form['enable'] = array(
       '#type' => 'checkbox',

--- a/core/modules/system/system.info
+++ b/core/modules/system/system.info
@@ -1,10 +1,9 @@
+type = module
 name = System
 description = Handles general site configuration for administrators.
 package = System
-tags[] = System
-tags[] = Core
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE
+
 configure = admin/config/system

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -178,7 +178,7 @@ function theme_system_modules_fieldset($variables) {
     if ($required_by) {
       $requirements .= '<div class="admin-requirements">' . t('Required by: !module-list', array('!module-list' => implode(', ', $module['#required_by']))) . '</div>';
     }
-    $requirements .= '<div class="admin-requirements module-tags">' . t('Tags: !tags', array('!tags' => backdrop_render($module['tags']))) . '</div>';
+    $requirements .= '<div class="admin-requirements">' . t('Tags: <span class="module-tags">!tags</span>', array('!tags' => backdrop_render($module['tags']))) . '</div>';
     $requirements .= '</div>';
 
     // Build a requirements toggle.
@@ -195,7 +195,12 @@ function theme_system_modules_fieldset($variables) {
 
     // Hide modules that can't be disabled at all.
     if (!$module["#required_by_distribution"]) {
-      $rows[] = $row;
+      $classes = array('contrib');
+      if ($module['core'] == TRUE) {
+        $classes = array('core');
+      }
+
+      $rows[] = array('data' => $row, 'class' => $classes);
     }
   }
 

--- a/core/modules/system/system.theme.inc
+++ b/core/modules/system/system.theme.inc
@@ -146,8 +146,7 @@ function theme_system_modules_fieldset($variables) {
 
   // Individual table headers.
   $rows = array();
-  // Iterate through all the modules, which are
-  // children of this fieldset.
+  // Iterate through all the modules, which are children of this fieldset.
   foreach (element_children($form) as $key) {
     // Stick the key into $module for easier access.
     $module = $form[$key];
@@ -195,11 +194,15 @@ function theme_system_modules_fieldset($variables) {
 
     // Hide modules that can't be disabled at all.
     if (!$module["#required_by_distribution"]) {
-      $classes = array('contrib');
       if ($module['core'] == TRUE) {
         $classes = array('core');
       }
-
+      elseif ($module['contrib'] == TRUE) {
+        $classes = array('contrib');
+      }
+      else {
+        $classes = array('custom');
+      }
       $rows[] = array('data' => $row, 'class' => $classes);
     }
   }

--- a/core/modules/taxonomy/taxonomy.info
+++ b/core/modules/taxonomy/taxonomy.info
@@ -2,11 +2,10 @@ name = Taxonomy
 description = Enables the organization of content by category.
 package = Categorization
 tags[] = Taxonomy
-tags[] = Categorization
-tags[] = Core
 version = BACKDROP_VERSION
 type = module
 backdrop = 1.x
 dependencies[] = options
 dependencies[] = entity
+
 configure = admin/structure/taxonomy

--- a/core/modules/translation/translation.info
+++ b/core/modules/translation/translation.info
@@ -1,9 +1,8 @@
+type = module
 name = Content Translation
 description = Allows content to be translated into different languages.
 dependencies[] = locale
-package = Language and Translation
-tags[] = Translation
-tags[] = Core
+package = Translation
+tags[] = Language
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x

--- a/core/modules/update/update.info
+++ b/core/modules/update/update.info
@@ -1,9 +1,9 @@
+type = module
 name = Update Manager
 description = Checks for available updates.
-version = BACKDROP_VERSION
-type = module
 package = Development
-tags[] = Development
-tags[] = Core
+tags[] = Utility
+version = BACKDROP_VERSION
 backdrop = 1.x
+
 configure = admin/reports/updates/settings

--- a/core/modules/user/user.info
+++ b/core/modules/user/user.info
@@ -1,12 +1,12 @@
+type = module
 name = User
 description = Manages the user registration and login system.
 package = System
-tags[] = System
-tags[] = User Management
-tags[] = Core
+tags[] = Account Management
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 required = TRUE
+
 configure = admin/config/people
+
 stylesheets[all][] = css/user.css

--- a/core/modules/views/views.info
+++ b/core/modules/views/views.info
@@ -1,10 +1,9 @@
+type = module
 name = Views
 description = Create customized lists and queries from your database.
 package = Views
-tags[] = Views
-tags[] = Core
+tags[] = Site Architecture
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
 stylesheets[all][] = css/views.css
 required = TRUE

--- a/core/modules/views_ui/views_ui.info
+++ b/core/modules/views_ui/views_ui.info
@@ -1,11 +1,10 @@
+type = module
 name = Views UI
 description = Administrative interface to views. Without this module, you cannot create or configure views.
 package = Views
-tags[] = Views
-tags[] = Content Display
-tags[] = Core
+tags[] = User Interface
 version = BACKDROP_VERSION
-type = module
 backdrop = 1.x
-configure = admin/structure/views
 dependencies[] = views
+
+configure = admin/structure/views

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -777,8 +777,15 @@ div.teaser-checkbox .form-item,
 .text-format-wrapper .form-item {
   padding-bottom: 0;
 }
+.form-item {
+  margin-top: .5em;
+  margin-bottom: .5em;
+}
 .form-item label {
-  margin: 0 0 10px;
+  margin: 0 0 5px;
+}
+.views-exposed-form label {
+  margin: 0 0 5px;
 }
 fieldset label {
   font-weight: normal;


### PR DESCRIPTION
We should account for custom modules ;)

...I would prefer it if we had some better way to distinguish contrib vs custom modules, but for now I am relying on the assumption that custom modules will not have this block of info in their `.info` file:

```
; Added by Backdrop CMS packaging script on yyyy-mm-dd
project = xyz
version = 1.x-1.2.3
timestamp = 1234567890
```