### PR TITLE
...only trim db version for telemetry

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -197,18 +197,11 @@ function system_requirements($phase) {
     }
   }
   else {
-    // Database information.
-    $class = 'DatabaseTasks_' . Database::getConnection()->driver();
-    /* @var DatabaseTasks $tasks */
-    $tasks = new $class();
-
-    $db_version = _system_get_database_version();
-
-    $dbinfo = $t('!system version !version', array('!system' => $tasks->name(), '!version' => $db_version));
+    $db_info = _system_get_database_version();
     $requirements['database_system'] = array(
-      'title' => $t('MySQL Database'),
+      'title' => $t('Database server'),
       'severity' => REQUIREMENT_INFO,
-      'value' => $dbinfo,
+      'value' => implode(' ', $db_info),
     );
   }
 

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -1122,7 +1122,7 @@ function _system_batch_theme() {
 }
 
 /**
- * Helper function to determine the type and version the databaser server.
+ * Helper function to determine the type and version of the databaser server.
  *
  * @return array
  *   An array with the following two keys:

--- a/core/modules/system/system.module
+++ b/core/modules/system/system.module
@@ -1122,7 +1122,12 @@ function _system_batch_theme() {
 }
 
 /**
- * Helper function to deterine the MySQL or MariaDB versionl
+ * Helper function to determine the type and version the databaser server.
+ *
+ * @return array
+ *   An array with the following two keys:
+ *   - 'type': (string) Either "MariaDB" or "MySQL".
+ *   - 'version': (string) The semantic version of the database server.
  *
  * @see system_requirements().
  * @see telemetry_telemetry_data().
@@ -1153,12 +1158,8 @@ function _system_get_database_version() {
     // Get the greatest version (or the only version).
     $version = $versions[0];
   }
-  // Trim the version number to only major + minor, otherwise we'd flood the
-  // table with dozens of bug fix versions.
-  $version = explode(".", $version);
-  $version = array_slice($version, 0, 2);
-  $version = implode('.', $version);
-  return $type . ' v' . $version;
+
+  return array('type' => $type, 'version' => $version);
 }
 
 /**

--- a/core/modules/telemetry/telemetry.telemetry.inc
+++ b/core/modules/telemetry/telemetry.telemetry.inc
@@ -44,7 +44,13 @@ function telemetry_telemetry_data($key) {
     case 'php_version':
       return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
     case 'mysql_version':
-      return _system_get_database_version();
+      // Trim the version number to only major + minor, otherwise we'd flood the
+      // table with dozens of bug fix versions.
+      $db_info = _system_get_database_version();
+      $version = explode('.', $db_info['version']);
+      $version = array_slice($version, 0, 2);
+      $version = implode('.', $version);
+      return $db_info['type'] . ' ' . $version;
     case 'server_os':
       return PHP_OS;
     case 'web_server':


### PR DESCRIPTION
@jenlampton here's a PR against yours. As per my comment in https://github.com/backdrop/backdrop/pull/4346/files#r1109183544:

> Since this version number is going to be used in multiple places, where in some of them the bug version may be important, we shouldn't be doing this here. Perhaps this function should be returning an array of separate type and version number, and then we can be doing the concatenation and trimming of the less significant version numbers only where appropriate. For example, use only 2 digits in telemetry, but the entire version number in the site status report.