### PR TITLE
Update user_compare_layout_access.inc

### DIFF
--- a/core/modules/layout/plugins/access/user_compare_layout_access.inc
+++ b/core/modules/layout/plugins/access/user_compare_layout_access.inc
@@ -82,7 +82,7 @@ class UserCompareLayoutAccess extends LayoutAccess {
     }
     $form['equality'] = array(
       '#type' => 'radios',
-      '#title' => t('Display this block if the above user account is'),
+      '#title' => t('Display if the above user account is'),
       '#options' => array(
         1 => t('the same as the logged-in user account.'),
         0 => t('different from the logged-in user account.'),


### PR DESCRIPTION
@jenlampton - Here is a PR that simply removes words "this block" to make the text less specific and such that it will apply to both layouts and blocks. 
